### PR TITLE
Add resizable row support to grid component

### DIFF
--- a/web/iron-logic-dashboard/src/app/features/admin/components/user-management/user-management.html
+++ b/web/iron-logic-dashboard/src/app/features/admin/components/user-management/user-management.html
@@ -88,6 +88,7 @@
       </div>
       <div class="p-4 grid-shell">
         <app-grid
+          [resizableRows]="true"
           class="h-full w-full"
           [columns]="userColumns"
           [data]="filteredUsers()"

--- a/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.css
+++ b/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.css
@@ -3,6 +3,10 @@
   width: 100%;
 }
 
+.grid-row {
+  transition: opacity 0.3s ease, filter 0.3s ease;
+}
+
 .row-resizer {
   position: absolute;
   left: 0;

--- a/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.css
+++ b/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.css
@@ -3,6 +3,31 @@
   width: 100%;
 }
 
+.row-resizer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -4px;
+  height: 8px;
+  cursor: row-resize;
+  z-index: 35;
+}
+
+.row-resizer::before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 3px;
+  border-top: 1px solid transparent;
+  transition: border-color 140ms ease;
+}
+
+.row-resizer:hover::before,
+.row-resizing .row-resizer::before {
+  border-top-color: #c7d2fe;
+}
+
 .badge-finance-plan-gold {
   background-color: var(--finance-100);
   color: var(--finance-700);

--- a/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.html
+++ b/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.html
@@ -1,14 +1,18 @@
 <div>
-  <div *ngFor="let row of data$ | async"
-  class="flex flex-nowrap items-center justify-start h-16 border-b border-slate-100 hover:bg-slate-50 transition-colors bg-white cursor-pointer px-2"
+    <div *ngFor="let row of data$ | async; let rowIndex = index"
+    class="relative flex flex-nowrap items-center justify-start border-b border-slate-100 hover:bg-slate-50 transition-colors bg-white cursor-pointer px-2"
        [class.min-w-full]="!fitViewportMode"
        [class.w-max]="!fitViewportMode"
        [style.width]="fitViewportMode ? '100%' : null"
        [style.max-width]="fitViewportMode ? '100%' : null"
+      [style.height]="getRowHeight(rowIndex)"
+      [style.min-height.px]="minRowHeight"
        style="display: flex; flex-wrap: nowrap;"
+      [attr.data-grid-row]="rowIndex"
        [class.ring-1]="row.isSelected"
        [class.ring-slate-300]="row.isSelected"
        [class.bg-slate-50]="row.isSelected"
+      [class.row-resizing]="isRowResizing(rowIndex)"
        (click)="onRowClick(row)">
 
     <div *ngFor="let col of visibleColumns"
@@ -169,6 +173,10 @@
       </ng-container>
 
     </div>
+
+        <div *ngIf="resizableRows"
+          class="row-resizer"
+              (mousedown)="onRowResizeStart(rowIndex, $event)"></div>
   </div>
 
   <div *ngIf="isBatchMode() && batchChanges.size > 0" class="sticky bottom-0 z-20 mt-1 bg-white/95 backdrop-blur-sm border border-indigo-100 rounded-xl p-3 flex items-center justify-between">

--- a/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.html
+++ b/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.html
@@ -1,96 +1,144 @@
 <div>
-    <div *ngFor="let row of data$ | async; let rowIndex = index"
-    class="relative flex flex-nowrap items-center justify-start border-b border-slate-100 hover:bg-slate-50 transition-colors bg-white cursor-pointer px-2"
-       [class.min-w-full]="!fitViewportMode"
-       [class.w-max]="!fitViewportMode"
-       [style.width]="fitViewportMode ? '100%' : null"
-       [style.max-width]="fitViewportMode ? '100%' : null"
-      [style.height]="getRowHeight(rowIndex)"
-      [style.min-height.px]="minRowHeight"
-       style="display: flex; flex-wrap: nowrap;"
-      [attr.data-grid-row]="rowIndex"
-       [class.ring-1]="row.isSelected"
-       [class.ring-slate-300]="row.isSelected"
-       [class.bg-slate-50]="row.isSelected"
-      [class.row-resizing]="isRowResizing(rowIndex)"
-       (click)="onRowClick(row)">
-
-    <div *ngFor="let col of visibleColumns"
-          class="flex items-center px-4 overflow-hidden whitespace-nowrap transition-[width] duration-300 ease-out"
-         [style.width]="fitViewportMode ? (col.width || 'auto') : (col.width || '150px')"
-         [style.max-width]="fitViewportMode ? (col.width || 'auto') : null"
-         [style.flex]="fitViewportMode ? '1 1 auto' : null"
-         [class.sticky]="!!col.locked"
-          [class.left-0]="!!col.locked"
-         [style.left]="col.locked ? getLockedOffset(col.field) : null"
-         [class.z-30]="!!col.locked"
-         [class.bg-white]="!!col.locked"
-         [class.border-r-2]="!!col.locked && isLastLocked(col.field)"
-         [class.border-slate-200]="!!col.locked && isLastLocked(col.field)"
-         [class.justify-center]="['badge', 'tier', 'number', 'status', 'selection'].includes(col.type || '')"
-         [class.justify-start]="!['badge', 'tier', 'number', 'status', 'selection'].includes(col.type || '') && col.type !== 'action'"
-         [class.justify-end]="col.type === 'action'"
-         [class.pr-4]="col.type === 'action'">
-
+  <div
+    *ngFor="let row of data$ | async; let rowIndex = index"
+    class="grid-row relative flex flex-nowrap items-center justify-start border-b border-slate-100 hover:bg-slate-50 transition-colors bg-white cursor-pointer px-2"
+    [class.min-w-full]="!fitViewportMode"
+    [class.w-max]="!fitViewportMode"
+    [style.width]="fitViewportMode ? '100%' : null"
+    [style.max-width]="fitViewportMode ? '100%' : null"
+    [style.height]="getRowHeight(rowIndex)"
+    [style.min-height.px]="minRowHeight"
+    style="display: flex; flex-wrap: nowrap"
+    [attr.data-grid-row]="rowIndex"
+    [class.ring-1]="row.isSelected"
+    [class.ring-slate-300]="row.isSelected"
+    [class.bg-slate-50]="row.isSelected"
+    [class.row-resizing]="isRowResizing(rowIndex)"
+    (click)="onRowClick(row, rowIndex)"
+  >
+    <div
+      *ngFor="let col of visibleColumns"
+      class="grid-cell flex items-center px-4 overflow-hidden whitespace-nowrap transition-[width] duration-300 ease-out"
+      [style.width]="fitViewportMode ? col.width || 'auto' : col.width || '150px'"
+      [style.max-width]="fitViewportMode ? col.width || 'auto' : null"
+      [style.flex]="fitViewportMode ? '1 1 auto' : null"
+      [class.sticky]="!!col.locked"
+      [class.left-0]="!!col.locked"
+      [style.left]="col.locked ? getLockedOffset(col.field) : null"
+      [class.z-30]="!!col.locked"
+      [class.is-frozen]="!!col.locked"
+      [class.bg-white]="!!col.locked"
+      [class.border-r-2]="!!col.locked && isLastLocked(col.field)"
+      [class.border-slate-200]="!!col.locked && isLastLocked(col.field)"
+      [class.justify-center]="
+        ['badge', 'tier', 'number', 'status', 'selection'].includes(col.type || '')
+      "
+      [class.justify-start]="
+        !['badge', 'tier', 'number', 'status', 'selection'].includes(col.type || '') &&
+        col.type !== 'action'
+      "
+      [class.justify-end]="col.type === 'action'"
+      [class.pr-4]="col.type === 'action'"
+    >
       <ng-container *ngIf="col.type === 'selection'">
-        <input type="checkbox"
-               [(ngModel)]="row.isSelected"
-               (change)="onRowSelect(row)"
-               (click)="$event.stopPropagation()"
-               class="w-4 h-4 rounded border-slate-300 text-black focus:ring-black cursor-pointer">
+        <input
+          type="checkbox"
+          [(ngModel)]="row.isSelected"
+          (change)="onRowSelect(row)"
+          (click)="$event.stopPropagation()"
+          class="w-4 h-4 rounded border-slate-300 text-black focus:ring-black cursor-pointer"
+        />
       </ng-container>
 
       <ng-container *ngIf="isCellInEditMode(row, col)">
-        <input [ngModel]="row[col.field]"
-               (click)="$event.stopPropagation()"
-               (ngModelChange)="onBatchValueChange(row, col, $event)"
-               class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-slate-200 rounded outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all"
-               [class.border-indigo-300]="isBatchMode() && isBatchFieldDirty(row, col.field)"
-               [class.bg-indigo-50]="isBatchMode() && isBatchFieldDirty(row, col.field)">
+        <input
+          [ngModel]="row[col.field]"
+          (click)="$event.stopPropagation()"
+          (ngModelChange)="onBatchValueChange(row, col, $event)"
+          class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-slate-200 rounded outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all"
+          [class.border-indigo-300]="isBatchMode() && isBatchFieldDirty(row, col.field)"
+          [class.bg-indigo-50]="isBatchMode() && isBatchFieldDirty(row, col.field)"
+        />
       </ng-container>
 
       <ng-container *ngIf="(!col.type || col.type === 'text') && !isCellInEditMode(row, col)">
-        <span class="block w-full truncate text-[13px] text-slate-600 font-medium" [attr.title]="row[col.field]">{{ row[col.field] }}</span>
+        <span
+          class="block w-full truncate text-[13px] text-slate-600 font-medium"
+          [attr.title]="row[col.field]"
+          >{{ row[col.field] }}</span
+        >
       </ng-container>
 
       <ng-container *ngIf="col.type === 'number' && !isCellInEditMode(row, col)">
-        <span class="text-[13px] text-slate-600 font-medium text-center w-full">{{ row[col.field] }}</span>
+        <span class="text-[13px] text-slate-600 font-medium text-center w-full">{{
+          row[col.field]
+        }}</span>
       </ng-container>
 
       <ng-container *ngIf="col.type === 'profile'">
         <div class="flex items-center gap-3">
-          <div class="w-9 h-9 rounded-full overflow-hidden bg-slate-100 border border-slate-200 shrink-0 flex items-center justify-center">
-            <img *ngIf="row['profileImageUrl']"
-                 [src]="row['profileImageUrl']"
-                 alt=""
-                 class="w-full h-full object-cover">
-            <span *ngIf="!row['profileImageUrl']" class="text-[11px] font-bold text-slate-600">{{ (row[col.field] || '?')[0] | uppercase }}</span>
+          <div
+            class="w-9 h-9 rounded-full overflow-hidden bg-slate-100 border border-slate-200 shrink-0 flex items-center justify-center"
+          >
+            <img
+              *ngIf="row['profileImageUrl']"
+              [src]="row['profileImageUrl']"
+              alt=""
+              class="w-full h-full object-cover"
+            />
+            <span *ngIf="!row['profileImageUrl']" class="text-[11px] font-bold text-slate-600">{{
+              (row[col.field] || '?')[0] | uppercase
+            }}</span>
           </div>
           <div class="flex flex-col">
-            <span *ngIf="!isInlineEditingRow(row)" class="font-bold text-slate-900 text-[13px]">{{ row[col.field] }}</span>
-            <input *ngIf="isInlineEditingRow(row)"
-                   type="text"
-                   [(ngModel)]="row[col.field]"
-                   (click)="$event.stopPropagation()"
-                   class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-indigo-300 rounded outline-none focus:ring-2 focus:ring-indigo-100 transition-all">
+            <span *ngIf="!isInlineEditingRow(row)" class="font-bold text-slate-900 text-[13px]">{{
+              row[col.field]
+            }}</span>
+            <input
+              *ngIf="isInlineEditingRow(row)"
+              type="text"
+              [(ngModel)]="row[col.field]"
+              (click)="$event.stopPropagation()"
+              class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-indigo-300 rounded outline-none focus:ring-2 focus:ring-indigo-100 transition-all"
+            />
 
-            <span *ngIf="!isInlineEditingRow(row)" class="text-[11px] font-medium text-slate-400 mt-0.5">{{ col.subfield ? row[col.subfield] : ('USR-' + (row['id'] | slice:0:4)) }}</span>
-            <input *ngIf="isInlineEditingRow(row) && col.subfield"
-                   type="text"
-                   [(ngModel)]="row[col.subfield]"
-                   (click)="$event.stopPropagation()"
-                   class="w-full h-8 mt-1 px-2 text-[12px] font-medium bg-white border border-indigo-300 rounded outline-none focus:ring-2 focus:ring-indigo-100 transition-all">
+            <span
+              *ngIf="!isInlineEditingRow(row)"
+              class="text-[11px] font-medium text-slate-400 mt-0.5"
+              >{{ col.subfield ? row[col.subfield] : 'USR-' + (row['id'] | slice: 0 : 4) }}</span
+            >
+            <input
+              *ngIf="isInlineEditingRow(row) && col.subfield"
+              type="text"
+              [(ngModel)]="row[col.subfield]"
+              (click)="$event.stopPropagation()"
+              class="w-full h-8 mt-1 px-2 text-[12px] font-medium bg-white border border-indigo-300 rounded outline-none focus:ring-2 focus:ring-indigo-100 transition-all"
+            />
           </div>
         </div>
       </ng-container>
 
       <ng-container *ngIf="col.type === 'image'">
-        <div class="flex items-center justify-center w-10 h-10 rounded-[10px] bg-slate-50 border border-slate-100 overflow-hidden shrink-0 shadow-sm">
-          <img *ngIf="row[col.field]"
-               [src]="row[col.field]"
-               alt=""
-               class="w-full h-full object-cover hover:scale-110 transition-transform duration-300">
-          <svg *ngIf="!row[col.field]" class="w-4 h-4 text-slate-300" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <div
+          class="flex items-center justify-center w-10 h-10 rounded-[10px] bg-slate-50 border border-slate-100 overflow-hidden shrink-0 shadow-sm"
+        >
+          <img
+            *ngIf="row[col.field]"
+            [src]="row[col.field]"
+            alt=""
+            class="w-full h-full object-cover hover:scale-110 transition-transform duration-300"
+          />
+          <svg
+            *ngIf="!row[col.field]"
+            class="w-4 h-4 text-slate-300"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
             <rect x="3" y="3" width="18" height="18" rx="2"></rect>
             <circle cx="8.5" cy="8.5" r="1.5"></circle>
             <path d="M21 15l-5-5L5 21"></path>
@@ -99,41 +147,78 @@
       </ng-container>
 
       <ng-container *ngIf="col.type === 'badge'">
-        <span class="inline-flex items-center justify-center text-center rounded-md px-3 py-1 text-[11px] font-medium"
-              [class]="'inline-flex items-center justify-center text-center rounded-md px-3 py-1 text-[11px] font-medium ' + getBadgeClass(col, row)">
+        <span
+          class="inline-flex items-center justify-center text-center rounded-md px-3 py-1 text-[11px] font-medium"
+          [class]="
+            'inline-flex items-center justify-center text-center rounded-md px-3 py-1 text-[11px] font-medium ' +
+            getBadgeClass(col, row)
+          "
+        >
           {{ row[col.field] }}
         </span>
       </ng-container>
 
       <ng-container *ngIf="col.type === 'tier'">
-        <span class="inline-flex items-center justify-center text-center rounded-md px-3 py-1 text-[11px] font-bold tracking-tight uppercase"
-              [ngClass]="{
-                'bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-200': row[col.field] === 'Elite' || row[col.field] === 'Premium',
-                'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200': row[col.field] === 'Pro',
-                'bg-slate-100 text-slate-600 ring-1 ring-inset ring-slate-200': row[col.field] === 'Basic' || row[col.field] === 'Free'
-              }">
+        <span
+          class="inline-flex items-center justify-center text-center rounded-md px-3 py-1 text-[11px] font-bold tracking-tight uppercase"
+          [ngClass]="{
+            'bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-200':
+              row[col.field] === 'Elite' || row[col.field] === 'Premium',
+            'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200': row[col.field] === 'Pro',
+            'bg-slate-100 text-slate-600 ring-1 ring-inset ring-slate-200':
+              row[col.field] === 'Basic' || row[col.field] === 'Free',
+          }"
+        >
           {{ row[col.field] }}
         </span>
       </ng-container>
 
       <ng-container *ngIf="col.type === 'email' && !isCellInEditMode(row, col)">
         <div class="flex items-center gap-2">
-          <svg *ngIf="row['status'] !== 'Suspended'" class="w-4 h-4 text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7l6.2 4.65a3 3 0 003.6 0L20 7"/><rect x="3" y="5" width="18" height="14" rx="2"/></svg>
-          <svg *ngIf="row['status'] === 'Suspended'" class="w-4 h-4 text-amber-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          <svg
+            *ngIf="row['status'] !== 'Suspended'"
+            class="w-4 h-4 text-emerald-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path d="M4 7l6.2 4.65a3 3 0 003.6 0L20 7" />
+            <rect x="3" y="5" width="18" height="14" rx="2" />
+          </svg>
+          <svg
+            *ngIf="row['status'] === 'Suspended'"
+            class="w-4 h-4 text-amber-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+          </svg>
           <span class="text-[13px] text-slate-600 font-medium">{{ row[col.field] }}</span>
         </div>
       </ng-container>
 
       <ng-container *ngIf="col.type === 'calendar'">
         <div class="flex items-center gap-2 text-slate-600">
-          <svg class="w-4 h-4 text-slate-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            class="w-4 h-4 text-slate-400"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
             <line x1="16" y1="2" x2="16" y2="6"></line>
             <line x1="8" y1="2" x2="8" y2="6"></line>
             <line x1="3" y1="10" x2="21" y2="10"></line>
           </svg>
           <span class="text-[12px] font-semibold text-slate-700">
-            {{ row[col.field] ? (row[col.field] | date:'MMM d, y, h:mm a') : '-' }}
+            {{ row[col.field] ? (row[col.field] | date: 'MMM d, y, h:mm a') : '-' }}
           </span>
         </div>
       </ng-container>
@@ -141,89 +226,133 @@
       <ng-container *ngIf="col.type === 'date'">
         <div class="flex items-center text-slate-600">
           <span class="text-[12px] font-semibold text-slate-700">
-            {{ row[col.field] ? (row[col.field] | date:'MMM d, y') : '-' }}
+            {{ row[col.field] ? (row[col.field] | date: 'MMM d, y') : '-' }}
           </span>
         </div>
       </ng-container>
 
       <ng-container *ngIf="col.type === 'action' || col.field === 'actions'">
         <div class="flex items-center gap-1">
-          <button *ngIf="isInlineEditingRow(row)"
+          <button
+            *ngIf="isInlineEditingRow(row)"
             (click)="saveInlineEdit(row, $event)"
-                  class="p-1 text-emerald-600 hover:text-emerald-700 transition-colors"
-                  title="Save">
+            class="p-1 text-emerald-600 hover:text-emerald-700 transition-colors"
+            title="Save"
+          >
             <lucide-icon name="check" class="w-4 h-4"></lucide-icon>
           </button>
-          <button *ngIf="isInlineEditingRow(row)"
+          <button
+            *ngIf="isInlineEditingRow(row)"
             (click)="cancelInlineEdit(row, $event)"
-                  class="p-1 text-rose-600 hover:text-rose-700 transition-colors"
-                  title="Cancel">
+            class="p-1 text-rose-600 hover:text-rose-700 transition-colors"
+            title="Cancel"
+          >
             <lucide-icon name="x" class="w-4 h-4"></lucide-icon>
           </button>
 
-          <button *ngIf="!isInlineEditingRow(row) && !(isBatchMode() && editSettings.allowEditing)"
+          <button
+            *ngIf="!isInlineEditingRow(row) && !(isBatchMode() && editSettings.allowEditing)"
             (click)="onAction(getActionType(col), row, $event)"
-                  class="p-1 text-slate-400 hover:text-slate-700 transition-colors"
-                  [attr.title]="getActionTitle(col)">
+            class="p-1 text-slate-400 hover:text-slate-700 transition-colors"
+            [attr.title]="getActionTitle(col)"
+          >
             <lucide-icon [name]="getActionIcon(col)" class="w-5 h-5"></lucide-icon>
           </button>
 
-          <span *ngIf="isBatchMode() && editSettings.allowEditing" class="text-[10px] font-semibold text-slate-300">-</span>
+          <span
+            *ngIf="isBatchMode() && editSettings.allowEditing"
+            class="text-[10px] font-semibold text-slate-300"
+            >-</span
+          >
         </div>
       </ng-container>
-
     </div>
 
-        <div *ngIf="resizableRows"
-          class="row-resizer"
-              (mousedown)="onRowResizeStart(rowIndex, $event)"></div>
+    <div
+      *ngIf="resizableRows"
+      class="row-resizer"
+      (mousedown)="onRowResizeStart(rowIndex, $event)"
+    ></div>
   </div>
 
-  <div *ngIf="isBatchMode() && batchChanges.size > 0" class="sticky bottom-0 z-20 mt-1 bg-white/95 backdrop-blur-sm border border-indigo-100 rounded-xl p-3 flex items-center justify-between">
-    <span class="text-[11px] font-semibold text-indigo-700">{{ batchChanges.size }} row(s) pending changes</span>
+  <div
+    *ngIf="isBatchMode() && batchChanges.size > 0"
+    class="sticky bottom-0 z-20 mt-1 bg-white/95 backdrop-blur-sm border border-indigo-100 rounded-xl p-3 flex items-center justify-between"
+  >
+    <span class="text-[11px] font-semibold text-indigo-700"
+      >{{ batchChanges.size }} row(s) pending changes</span
+    >
     <div class="flex items-center gap-2">
-      <button (click)="cancelBatchEdit()"
-              class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all">
+      <button
+        (click)="cancelBatchEdit()"
+        class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all"
+      >
         Cancel
       </button>
-      <button (click)="saveBatchEdit()"
-              class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-all">
+      <button
+        (click)="saveBatchEdit()"
+        class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-all"
+      >
         Save All
       </button>
     </div>
   </div>
 
-  <div *ngIf="(data$ | async)?.length === 0" class="p-12 text-center text-[12px] font-bold text-slate-400">
+  <div
+    *ngIf="(data$ | async)?.length === 0"
+    class="p-12 text-center text-[12px] font-bold text-slate-400"
+  >
     No records found.
   </div>
 
-  <div *ngIf="isPopupMode() && popupEditData" class="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-50 flex items-center justify-center p-4" (click)="cancelPopupEdit()">
-    <div class="max-w-md w-full bg-white rounded-2xl p-6 shadow-2xl" (click)="$event.stopPropagation()">
+  <div
+    *ngIf="isPopupMode() && popupEditData"
+    class="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+    (click)="cancelPopupEdit()"
+  >
+    <div
+      class="max-w-md w-full bg-white rounded-2xl p-6 shadow-2xl"
+      (click)="$event.stopPropagation()"
+    >
       <h3 class="text-lg font-black text-slate-900 mb-4">Edit Record</h3>
 
       <div class="space-y-3">
         <ng-container *ngFor="let col of columns">
           <div *ngIf="isPopupPrimaryEditableColumn(col)">
-            <label class="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">{{ col.title }}</label>
-            <input [(ngModel)]="popupEditData[col.field]"
-                   class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-slate-200 rounded outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all">
+            <label
+              class="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1"
+              >{{ col.title }}</label
+            >
+            <input
+              [(ngModel)]="popupEditData[col.field]"
+              class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-slate-200 rounded outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all"
+            />
           </div>
 
           <div *ngIf="col.subfield">
-            <label class="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1">{{ getPopupSubfieldLabel(col) }}</label>
-            <input [(ngModel)]="popupEditData[col.subfield]"
-                   class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-slate-200 rounded outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all">
+            <label
+              class="block text-[11px] font-bold uppercase tracking-wide text-slate-500 mb-1"
+              >{{ getPopupSubfieldLabel(col) }}</label
+            >
+            <input
+              [(ngModel)]="popupEditData[col.subfield]"
+              class="w-full h-8 px-2 text-[12px] font-medium bg-white border border-slate-200 rounded outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all"
+            />
           </div>
         </ng-container>
       </div>
 
       <div class="mt-5 flex items-center justify-end gap-2">
-        <button (click)="cancelPopupEdit()"
-                class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all">
+        <button
+          (click)="cancelPopupEdit()"
+          class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-slate-100 text-slate-700 hover:bg-slate-200 transition-all"
+        >
           Cancel
         </button>
-        <button (click)="savePopupEdit()"
-                class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-all">
+        <button
+          (click)="savePopupEdit()"
+          class="px-3 py-1.5 text-[11px] font-bold rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-all"
+        >
           Save
         </button>
       </div>

--- a/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.ts
+++ b/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, Output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 import { ColumnConfig } from '../../models/column-config';
@@ -20,9 +20,10 @@ interface GridEditSettings {
   templateUrl: './grid-body.html',
   styleUrls: ['./grid-body.css']
 })
-export class GridBodyComponent {
+export class GridBodyComponent implements OnDestroy {
   @Input() columns: ColumnConfig[] = [];
   @Input() fitViewportMode: boolean = false;
+  @Input() resizableRows: boolean = true;
 
   get visibleColumns(): ColumnConfig[] {
     return this.columns.filter((col) => !col.hidden);
@@ -33,14 +34,27 @@ export class GridBodyComponent {
   @Output() action = new EventEmitter<{ type: string, row: any }>();
   @Output() saveChanges = new EventEmitter<any>();
   @Output() inlineSave = new EventEmitter<any>();
+  @Output() rowResize = new EventEmitter<{ rowIndex: number; height: number }>();
 
   editingRowId = signal<string | null>(null);
   private inlineOriginalData: any | null = null;
   popupEditData: any | null = null;
   popupOriginalData: any | null = null;
   batchChanges = new Map<string, Record<string, any>>();
+  readonly minRowHeight = 40;
+  private readonly defaultRowHeight = 64;
+  private readonly rowHeights: number[] = [];
+  private resizingRowIndex: number | null = null;
+  private rowResizeStartY = 0;
+  private rowResizeStartHeight = this.defaultRowHeight;
+  private readonly onWindowMouseMove = (event: MouseEvent) => this.onRowResizeMove(event);
+  private readonly onWindowMouseUp = () => this.onRowResizeEnd();
 
   constructor(private gridDataService: GridDataService) {}
+
+  ngOnDestroy(): void {
+    this.removeRowResizeListeners();
+  }
 
   onAction(type: string, row: any, event?: Event) {
     if(event) event.stopPropagation(); // جلوگیری از تداخل کلیک دکمه با کلیک سطر
@@ -311,6 +325,65 @@ export class GridBodyComponent {
 
   cancelBatchEdit(): void {
     this.batchChanges.clear();
+  }
+
+  getRowHeight(rowIndex: number): string {
+    const height = this.rowHeights[rowIndex] ?? this.defaultRowHeight;
+    return `${height}px`;
+  }
+
+  isRowResizing(rowIndex: number): boolean {
+    return this.resizingRowIndex === rowIndex;
+  }
+
+  onRowResizeStart(rowIndex: number, event: MouseEvent): void {
+    if (!this.resizableRows) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const rowElement = (event.currentTarget as HTMLElement | null)?.closest('[data-grid-row]') as HTMLElement | null;
+    const currentHeight = rowElement?.getBoundingClientRect().height
+      ?? this.rowHeights[rowIndex]
+      ?? this.defaultRowHeight;
+
+    this.resizingRowIndex = rowIndex;
+    this.rowResizeStartY = event.clientY;
+    this.rowResizeStartHeight = Math.max(this.minRowHeight, Math.round(currentHeight));
+
+    window.addEventListener('mousemove', this.onWindowMouseMove);
+    window.addEventListener('mouseup', this.onWindowMouseUp);
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'row-resize';
+  }
+
+  private onRowResizeMove(event: MouseEvent): void {
+    if (this.resizingRowIndex === null) {
+      return;
+    }
+
+    const delta = event.clientY - this.rowResizeStartY;
+    const nextHeight = Math.max(this.minRowHeight, Math.round(this.rowResizeStartHeight + delta));
+    this.rowHeights[this.resizingRowIndex] = nextHeight;
+    this.rowResize.emit({ rowIndex: this.resizingRowIndex, height: nextHeight });
+  }
+
+  private onRowResizeEnd(): void {
+    if (this.resizingRowIndex === null) {
+      return;
+    }
+
+    this.resizingRowIndex = null;
+    this.removeRowResizeListeners();
+  }
+
+  private removeRowResizeListeners(): void {
+    window.removeEventListener('mousemove', this.onWindowMouseMove);
+    window.removeEventListener('mouseup', this.onWindowMouseUp);
+    document.body.style.removeProperty('user-select');
+    document.body.style.removeProperty('cursor');
   }
 
   private getSafeWidth(width?: string): number {

--- a/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.ts
+++ b/web/iron-logic-dashboard/src/app/shared/grid/components/grid-body/grid-body.ts
@@ -18,7 +18,7 @@ interface GridEditSettings {
   standalone: true,
   imports: [CommonModule, FormsModule, LucideAngularModule],
   templateUrl: './grid-body.html',
-  styleUrls: ['./grid-body.css']
+  styleUrls: ['./grid-body.css'],
 })
 export class GridBodyComponent implements OnDestroy {
   @Input() columns: ColumnConfig[] = [];
@@ -31,7 +31,7 @@ export class GridBodyComponent implements OnDestroy {
 
   @Input() data$!: Observable<any[]>;
   @Input() editSettings: GridEditSettings = { mode: 'None', allowEditing: false };
-  @Output() action = new EventEmitter<{ type: string, row: any }>();
+  @Output() action = new EventEmitter<{ type: string; row: any }>();
   @Output() saveChanges = new EventEmitter<any>();
   @Output() inlineSave = new EventEmitter<any>();
   @Output() rowResize = new EventEmitter<{ rowIndex: number; height: number }>();
@@ -57,7 +57,7 @@ export class GridBodyComponent implements OnDestroy {
   }
 
   onAction(type: string, row: any, event?: Event) {
-    if(event) event.stopPropagation(); // جلوگیری از تداخل کلیک دکمه با کلیک سطر
+    if (event) event.stopPropagation(); // جلوگیری از تداخل کلیک دکمه با کلیک سطر
 
     if (this.editSettings.allowEditing && type === 'edit') {
       if (this.editSettings.mode === 'Inline') {
@@ -71,7 +71,7 @@ export class GridBodyComponent implements OnDestroy {
       }
     }
 
-    this.action.emit({type, row});
+    this.action.emit({ type, row });
   }
 
   onRowSelect(row: any) {
@@ -79,7 +79,7 @@ export class GridBodyComponent implements OnDestroy {
   }
 
   // متد جدید برای کلیک روی کل سطر (باز کردن Drawer)
-  onRowClick(row: any) {
+  onRowClick(row: any, rowIndex: number) {
     this.action.emit({ type: 'row-click', row });
   }
 
@@ -87,9 +87,7 @@ export class GridBodyComponent implements OnDestroy {
     const value = String(row[col.field] ?? '');
 
     if (col.badgeStyle === 'mechanics') {
-      return value === 'Compound'
-        ? 'badge-mechanics-compound'
-        : 'badge-mechanics-isolation';
+      return value === 'Compound' ? 'badge-mechanics-compound' : 'badge-mechanics-isolation';
     }
 
     if (col.badgeStyle === 'aiTag') {
@@ -97,15 +95,11 @@ export class GridBodyComponent implements OnDestroy {
     }
 
     if (col.badgeStyle === 'financePlan') {
-      return value === 'Gold'
-        ? 'badge-finance-plan-gold'
-        : 'badge-finance-plan-silver';
+      return value === 'Gold' ? 'badge-finance-plan-gold' : 'badge-finance-plan-silver';
     }
 
     if (col.badgeStyle === 'financeStatus') {
-      return value === 'Paid'
-        ? 'badge-finance-status-paid'
-        : 'badge-finance-status-pending';
+      return value === 'Paid' ? 'badge-finance-status-paid' : 'badge-finance-status-pending';
     }
 
     if (col.badgeStyle === 'verified') {
@@ -213,7 +207,11 @@ export class GridBodyComponent implements OnDestroy {
   }
 
   isInlineEditingRow(row: any): boolean {
-    return this.editSettings.allowEditing && this.editSettings.mode === 'Inline' && this.editingRowId() === row?.id;
+    return (
+      this.editSettings.allowEditing &&
+      this.editSettings.mode === 'Inline' &&
+      this.editingRowId() === row?.id
+    );
   }
 
   startInlineEdit(row: any): void {
@@ -234,7 +232,7 @@ export class GridBodyComponent implements OnDestroy {
     this.saveChanges.emit({
       mode: 'Inline',
       row: { ...row },
-      id: row?.id
+      id: row?.id,
     });
     this.editingRowId.set(null);
     this.inlineOriginalData = null;
@@ -284,7 +282,7 @@ export class GridBodyComponent implements OnDestroy {
     this.saveChanges.emit({
       mode: 'Popup',
       row: { ...this.popupEditData },
-      id: this.popupEditData.id
+      id: this.popupEditData.id,
     });
 
     this.popupEditData = null;
@@ -318,7 +316,10 @@ export class GridBodyComponent implements OnDestroy {
       return;
     }
 
-    const changes = Array.from(this.batchChanges.entries()).map(([id, values]) => ({ id, values: { ...values } }));
+    const changes = Array.from(this.batchChanges.entries()).map(([id, values]) => ({
+      id,
+      values: { ...values },
+    }));
     this.saveChanges.emit({ mode: 'Batch', changes });
     this.batchChanges.clear();
   }
@@ -344,10 +345,13 @@ export class GridBodyComponent implements OnDestroy {
     event.preventDefault();
     event.stopPropagation();
 
-    const rowElement = (event.currentTarget as HTMLElement | null)?.closest('[data-grid-row]') as HTMLElement | null;
-    const currentHeight = rowElement?.getBoundingClientRect().height
-      ?? this.rowHeights[rowIndex]
-      ?? this.defaultRowHeight;
+    const rowElement = (event.currentTarget as HTMLElement | null)?.closest(
+      '[data-grid-row]',
+    ) as HTMLElement | null;
+    const currentHeight =
+      rowElement?.getBoundingClientRect().height ??
+      this.rowHeights[rowIndex] ??
+      this.defaultRowHeight;
 
     this.resizingRowIndex = rowIndex;
     this.rowResizeStartY = event.clientY;

--- a/web/iron-logic-dashboard/src/app/shared/grid/grid.css
+++ b/web/iron-logic-dashboard/src/app/shared/grid/grid.css
@@ -80,3 +80,5 @@ app-grid-footer {
 .cdk-drop-list-dragging .header-cell:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
+
+

--- a/web/iron-logic-dashboard/src/app/shared/grid/grid.html
+++ b/web/iron-logic-dashboard/src/app/shared/grid/grid.html
@@ -155,10 +155,12 @@
     <app-grid-body
       [columns]="visibleColumns"
       [fitViewportMode]="isFitViewportMode"
+      [resizableRows]="resizableRows"
       [style.display]="'contents'"
       [data$]="pagedData$"
       [editSettings]="editSettings"
       (action)="actionTriggered.emit($event)"
+      (rowResize)="onRowResize()"
       (saveChanges)="saveChanges.emit($event)"
       (inlineSave)="inlineSave.emit($event)"
     >

--- a/web/iron-logic-dashboard/src/app/shared/grid/grid.html
+++ b/web/iron-logic-dashboard/src/app/shared/grid/grid.html
@@ -1,4 +1,6 @@
-<div class="flex h-full min-h-0 w-full flex-col gap-2 overflow-hidden">
+<div
+  class="grid-container flex h-full min-h-0 w-full flex-col gap-2 overflow-hidden"
+>
   <div class="mb-4 flex w-full items-center justify-between shrink-0">
     <div
       *ngIf="showSearch"
@@ -134,7 +136,7 @@
 
   <div
     #gridScrollContainer
-    class="min-h-0 flex-1 w-full overflow-auto custom-scrollbar border border-slate-200 rounded-2xl"
+    class="relative min-h-0 flex-1 w-full overflow-auto custom-scrollbar border border-slate-200 rounded-2xl"
     [class.fit-viewport-scroll]="isFitViewportMode"
     style="overflow-x: auto !important; display: block !important"
   >

--- a/web/iron-logic-dashboard/src/app/shared/grid/grid.ts
+++ b/web/iron-logic-dashboard/src/app/shared/grid/grid.ts
@@ -205,23 +205,21 @@ export class GridComponent implements OnInit, OnChanges {
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
-    if (!this.isColumnMenuOpen) {
-      return;
-    }
-
     const clickTarget = event.target as Node | null;
     const menuContainer = this.columnMenuContainerRef?.nativeElement;
 
-    if (menuContainer && clickTarget && !menuContainer.contains(clickTarget)) {
-      this.isColumnMenuOpen = false;
-      this.cdr.markForCheck();
-      return;
+    if (this.isColumnMenuOpen) {
+      if (menuContainer && clickTarget && !menuContainer.contains(clickTarget)) {
+        this.isColumnMenuOpen = false;
+        this.cdr.markForCheck();
+      }
+
+      if (!menuContainer && clickTarget && !this.elementRef.nativeElement.contains(clickTarget)) {
+        this.isColumnMenuOpen = false;
+        this.cdr.markForCheck();
+      }
     }
 
-    if (!menuContainer && clickTarget && !this.elementRef.nativeElement.contains(clickTarget)) {
-      this.isColumnMenuOpen = false;
-      this.cdr.markForCheck();
-    }
   }
 
   private captureInitialColumnWidths(): void {

--- a/web/iron-logic-dashboard/src/app/shared/grid/grid.ts
+++ b/web/iron-logic-dashboard/src/app/shared/grid/grid.ts
@@ -69,6 +69,7 @@ export class GridComponent implements OnInit, OnChanges {
   @Input() showFilters: boolean = false; // نمایش فیلترهای زیر هدر
   @Input() showSearch: boolean = true; // نمایش نوار جستجوی بالا
   @Input() pagerPosition: 'top' | 'bottom' | 'both' = 'bottom';
+  @Input() resizableRows: boolean = true;
   reorderable = input<boolean>(false);
 
   filterResetKey = 0;
@@ -150,6 +151,16 @@ export class GridComponent implements OnInit, OnChanges {
     this._searchTerm = String(term ?? '');
     this.gridDataService.setSearchTerm(this._searchTerm);
     this.search.emit(this._searchTerm);
+  }
+
+  onRowResize(): void {
+    const viewport = this.elementRef.nativeElement.querySelector('cdk-virtual-scroll-viewport') as {
+      checkViewportSize?: () => void;
+    } | null;
+
+    if (viewport?.checkViewportSize) {
+      viewport.checkViewportSize();
+    }
   }
 
   drop(event: CdkDragDrop<ColumnConfig[]>) {


### PR DESCRIPTION
Add resizable row support to grid component

Introduced resizableRows input to enable/disable row resizing in the grid. Added a draggable handle to each row for resizing, with mouse event handlers to update row height dynamically. Updated styles and templates to support the new feature. Emitted rowResize events and ensured proper cleanup of listeners. Triggered viewport recalculation on row resize for smooth scrolling.